### PR TITLE
Create tags 1.0[.0]

### DIFF
--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -57,7 +57,10 @@ jobs:
           push: true
           sbom: true
           platforms: linux/amd64,linux/arm64
-          tags: patrickfmarques/wireguard:1.0.0-${{ steps.datatime.outputs.DATETIME }}
+          tags: |
+            patrickfmarques/wireguard:1.0
+            patrickfmarques/wireguard:1.0.0
+            patrickfmarques/wireguard:1.0.0-${{ steps.datatime.outputs.DATETIME }}
 
       - name: Sign the images with GitHub OIDC Token
         env:


### PR DESCRIPTION
# Description

Create `1.0` and `1.0.0` tags, which will be used to create the initial deployment when using `argocd-image-updater` while we don't use a GitOps approach.